### PR TITLE
Agregue endpoint Get para devolver todos los productos

### DIFF
--- a/src/main/java/shop/nandoShop/nandoshop_app/config/SecurityConfig.java
+++ b/src/main/java/shop/nandoShop/nandoshop_app/config/SecurityConfig.java
@@ -31,12 +31,14 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers(
                                 "/v1/auth/login",
                                 "/v1/auth/register",
                                 "/v1/auth/me",
                                 "/v1/auth/google"
                         ).permitAll()
+                        .requestMatchers(HttpMethod.GET, "/v1/my_products").hasAuthority("SELLER")
                         .requestMatchers(HttpMethod.POST, "/v1/product").hasAnyAuthority("SELLER")
                         .requestMatchers(
                                 "/v1/admin/grant-seller-role",

--- a/src/main/java/shop/nandoShop/nandoshop_app/controllers/v1/ProductController.java
+++ b/src/main/java/shop/nandoShop/nandoshop_app/controllers/v1/ProductController.java
@@ -4,13 +4,13 @@ import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import shop.nandoShop.nandoshop_app.dtos.ProductResponseDTO;
 import shop.nandoShop.nandoshop_app.dtos.requests.ProductRequest;
 import shop.nandoShop.nandoshop_app.entities.Product;
 import shop.nandoShop.nandoshop_app.services.interfaces.ProductService;
+
+import java.util.List;
 
 @Validated
 @RestController
@@ -23,5 +23,10 @@ public class ProductController {
     @PostMapping("/product")
     public ResponseEntity<Product> createProduct(@Valid @RequestBody ProductRequest productRequest) {
         return ResponseEntity.ok(productService.create(productRequest));
+    }
+
+    @GetMapping("/my_products")
+    public ResponseEntity<List<ProductResponseDTO>> showProductsPaginated() {
+        return ResponseEntity.ok(productService.showAllMyProducts());
     }
 }

--- a/src/main/java/shop/nandoShop/nandoshop_app/dtos/ProductResponseDTO.java
+++ b/src/main/java/shop/nandoShop/nandoshop_app/dtos/ProductResponseDTO.java
@@ -1,0 +1,29 @@
+package shop.nandoShop.nandoshop_app.dtos;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data
+public class ProductResponseDTO {
+    private Long id;
+    private String category;
+    private String name;
+    private String description;
+    private BigDecimal price;
+    private int stock;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public ProductResponseDTO(Long id, String category, String name, String description, BigDecimal price, int stock, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.category = category;
+        this.name = name;
+        this.description = description;
+        this.price = price;
+        this.stock = stock;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/shop/nandoShop/nandoshop_app/repositories/ProductRepository.java
+++ b/src/main/java/shop/nandoShop/nandoshop_app/repositories/ProductRepository.java
@@ -2,6 +2,11 @@ package shop.nandoShop.nandoshop_app.repositories;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import shop.nandoShop.nandoshop_app.entities.Product;
+import shop.nandoShop.nandoshop_app.entities.User;
+
+import java.util.List;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
+    List<Product> findBySeller(User seller);
+
 }

--- a/src/main/java/shop/nandoShop/nandoshop_app/services/impl/ProductServiceImpl.java
+++ b/src/main/java/shop/nandoShop/nandoshop_app/services/impl/ProductServiceImpl.java
@@ -2,6 +2,7 @@ package shop.nandoShop.nandoshop_app.services.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import shop.nandoShop.nandoshop_app.dtos.ProductResponseDTO;
 import shop.nandoShop.nandoshop_app.dtos.requests.ProductRequest;
 import shop.nandoShop.nandoshop_app.entities.Category;
 import shop.nandoShop.nandoshop_app.entities.Product;
@@ -10,6 +11,9 @@ import shop.nandoShop.nandoshop_app.repositories.CategoryRepository;
 import shop.nandoShop.nandoshop_app.repositories.ProductRepository;
 import shop.nandoShop.nandoshop_app.repositories.UserRepository;
 import shop.nandoShop.nandoshop_app.services.interfaces.ProductService;
+import shop.nandoShop.nandoshop_app.utils.AuthUtil;
+
+import java.util.List;
 
 @Service
 public class ProductServiceImpl implements ProductService {
@@ -46,5 +50,24 @@ public class ProductServiceImpl implements ProductService {
         catch (Exception e) {
             throw new RuntimeException("Error al crear la entidad Product: "+e.getMessage(), e);
         }
+    }
+
+    @Override
+    public List<ProductResponseDTO> showAllMyProducts() {
+        User user = userService.getCurrentUser();
+        List<Product> products = productRepository.findBySeller(user);
+
+        return products.stream()
+                .map(product -> new ProductResponseDTO(
+                        product.getId(),
+                        product.getCategory().getName(),
+                        product.getName(),
+                        product.getDescription(),
+                        product.getPrice(),
+                        product.getStock(),
+                        product.getCreatedAt(),
+                        product.getUpdatedAt()
+                ))
+                .toList();
     }
 }

--- a/src/main/java/shop/nandoShop/nandoshop_app/services/interfaces/ProductService.java
+++ b/src/main/java/shop/nandoShop/nandoshop_app/services/interfaces/ProductService.java
@@ -1,8 +1,12 @@
 package shop.nandoShop.nandoshop_app.services.interfaces;
 
+import shop.nandoShop.nandoshop_app.dtos.ProductResponseDTO;
 import shop.nandoShop.nandoshop_app.dtos.requests.ProductRequest;
 import shop.nandoShop.nandoshop_app.entities.Product;
 
+import java.util.List;
+
 public interface ProductService {
     Product create(ProductRequest productRequest);
+    List<ProductResponseDTO> showAllMyProducts();
 }

--- a/src/main/java/shop/nandoShop/nandoshop_app/utils/AuthUtil.java
+++ b/src/main/java/shop/nandoShop/nandoshop_app/utils/AuthUtil.java
@@ -1,0 +1,27 @@
+package shop.nandoShop.nandoshop_app.utils;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import shop.nandoShop.nandoshop_app.entities.User;
+
+public class AuthUtil {
+    public static User getCurrentUser() {
+        try {
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+            if (authentication == null || !authentication.isAuthenticated()) {
+                return null; // O podés lanzar una excepción si preferís manejarlo afuera
+            }
+
+            return (User) authentication.getPrincipal();
+        } catch (ClassCastException e) {
+            // Puede pasar si el principal no es de tipo User
+            System.err.println("Error al convertir el principal en User: " + e.getMessage());
+            return null;
+        } catch (Exception e) {
+            System.err.println("Error al obtener el usuario autenticado: " + e.getMessage());
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
This pull request introduces a new feature that allows sellers to view their own products through a paginated endpoint (`/v1/my_products`). It includes changes to the security configuration, controller, service layer, repository, and utility classes to support this functionality.

### Security Configuration Updates:
* Added permission for `OPTIONS` requests to all endpoints.
* Restricted access to the new `/v1/my_products` endpoint to users with the `SELLER` authority.

### Controller Enhancements:
* Added a new `GET` endpoint `/v1/my_products` in `ProductController` to fetch paginated products for the authenticated seller.

### Service Layer Changes:
* Implemented `showAllMyProducts` method in `ProductServiceImpl` to retrieve products for the current authenticated seller and map them to `ProductResponseDTO`.
* Updated `ProductService` interface to include the `showAllMyProducts` method.

### Data Transfer and Repository Updates:
* Created `ProductResponseDTO` to structure the product data returned by the new endpoint.
* Added `findBySeller` method to `ProductRepository` for querying products by seller.

### Utility Addition:
* Introduced `AuthUtil` class to simplify fetching the currently authenticated user.