### PR TITLE
feat(feat-add-file-product): Agregue file al post de prodcuto

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,17 @@
 			<artifactId>spring-dotenv</artifactId>
 			<version>4.0.0</version>
 		</dependency>
+<!-- Cloudinary -->
+		<dependency>
+			<groupId>com.cloudinary</groupId>
+			<artifactId>cloudinary-http5</artifactId>
+			<version>2.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.cloudinary</groupId>
+			<artifactId>cloudinary-taglib</artifactId>
+			<version>2.0.0</version>
+		</dependency>
 	</dependencies>
 
 

--- a/src/main/java/shop/nandoShop/nandoshop_app/config/CloudinaryConfig.java
+++ b/src/main/java/shop/nandoShop/nandoshop_app/config/CloudinaryConfig.java
@@ -1,0 +1,17 @@
+package shop.nandoShop.nandoshop_app.config;
+
+import com.cloudinary.Cloudinary;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CloudinaryConfig {
+    @Value("${cloudinary.url}")
+    private String cloudinaryUrl;
+
+    @Bean
+    public Cloudinary cloudinary() {
+        return new Cloudinary(cloudinaryUrl);
+    }
+}

--- a/src/main/java/shop/nandoShop/nandoshop_app/controllers/v1/ProductController.java
+++ b/src/main/java/shop/nandoShop/nandoshop_app/controllers/v1/ProductController.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 import shop.nandoShop.nandoshop_app.dtos.ProductResponseDTO;
 import shop.nandoShop.nandoshop_app.dtos.requests.ProductRequest;
@@ -16,6 +17,7 @@ import shop.nandoShop.nandoshop_app.dtos.requests.UpdateStockRequest;
 import shop.nandoShop.nandoshop_app.dtos.responses.ApiResponse;
 import shop.nandoShop.nandoshop_app.entities.Product;
 import shop.nandoShop.nandoshop_app.exceptions.NotFoundException;
+import shop.nandoShop.nandoshop_app.mappers.ProductMapper;
 import shop.nandoShop.nandoshop_app.services.interfaces.ProductService;
 
 import java.util.List;
@@ -29,9 +31,12 @@ public class ProductController {
     @Autowired
     ProductService productService;
 
-    @PostMapping("/product")
-    public ResponseEntity<Product> createProduct(@Valid @RequestBody ProductRequest productRequest) {
-        return ResponseEntity.ok(productService.create(productRequest));
+    @PostMapping(value = "/product",consumes = "multipart/form-data")
+    public ResponseEntity<ProductResponseDTO> createProduct(@Valid @ModelAttribute ProductRequest productRequest) {
+        Product product = productService.create(productRequest);
+        ProductResponseDTO dto = ProductMapper.toResponse(product);
+        return ResponseEntity.ok(dto);
+
     }
 
     @GetMapping("/my_products")

--- a/src/main/java/shop/nandoShop/nandoshop_app/dtos/AssetDTO.java
+++ b/src/main/java/shop/nandoShop/nandoshop_app/dtos/AssetDTO.java
@@ -1,0 +1,9 @@
+package shop.nandoShop.nandoshop_app.dtos;
+
+import java.util.Map;
+
+public record AssetDTO(String url, String publicId) {
+    public AssetDTO(Map<String, Object> asset) {
+        this(asset.get("url").toString(), asset.get("public_id").toString());
+    }
+}

--- a/src/main/java/shop/nandoShop/nandoshop_app/dtos/ProductResponseDTO.java
+++ b/src/main/java/shop/nandoShop/nandoshop_app/dtos/ProductResponseDTO.java
@@ -10,16 +10,18 @@ public class ProductResponseDTO {
     private Long id;
     private String category;
     private String name;
+    private String image;
     private String description;
     private BigDecimal price;
     private int stock;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
-    public ProductResponseDTO(Long id, String category, String name, String description, BigDecimal price, int stock, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    public ProductResponseDTO(Long id, String category, String name, String image, String description, BigDecimal price, int stock, LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
         this.category = category;
         this.name = name;
+        this.image = image;
         this.description = description;
         this.price = price;
         this.stock = stock;

--- a/src/main/java/shop/nandoShop/nandoshop_app/dtos/requests/ProductRequest.java
+++ b/src/main/java/shop/nandoShop/nandoshop_app/dtos/requests/ProductRequest.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.math.BigDecimal;
 
@@ -20,4 +21,6 @@ public class ProductRequest {
     private int stock;
     @NotNull(message = "La categoría es obligatoria")
     private Long categoryId;
+
+    private MultipartFile image;
 }

--- a/src/main/java/shop/nandoShop/nandoshop_app/entities/Product.java
+++ b/src/main/java/shop/nandoShop/nandoshop_app/entities/Product.java
@@ -36,6 +36,9 @@ public class Product {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
+    @Column(name = "image_url")
+    private String imageUrl;
+
     @PrePersist
     protected void onCreate() {
         createdAt = LocalDateTime.now();

--- a/src/main/java/shop/nandoShop/nandoshop_app/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/shop/nandoShop/nandoshop_app/exceptions/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package shop.nandoShop.nandoshop_app.exceptions;
 
+import org.apache.coyote.BadRequestException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;

--- a/src/main/java/shop/nandoShop/nandoshop_app/mappers/ProductMapper.java
+++ b/src/main/java/shop/nandoShop/nandoshop_app/mappers/ProductMapper.java
@@ -1,0 +1,21 @@
+package shop.nandoShop.nandoshop_app.mappers;
+
+import shop.nandoShop.nandoshop_app.dtos.ProductResponseDTO;
+import shop.nandoShop.nandoshop_app.entities.Product;
+
+public class ProductMapper {
+    public static ProductResponseDTO toResponse(Product product) {
+        return new ProductResponseDTO(
+                product.getId(),
+                product.getCategory().getName(),
+                product.getName(),
+                product.getImageUrl(),
+                product.getDescription(),
+                product.getPrice(),
+                product.getStock(),
+                product.getCreatedAt(),
+                product.getUpdatedAt()
+        );
+    }
+
+}

--- a/src/main/java/shop/nandoShop/nandoshop_app/services/impl/CloudinaryAssetsServiceImpl.java
+++ b/src/main/java/shop/nandoShop/nandoshop_app/services/impl/CloudinaryAssetsServiceImpl.java
@@ -1,0 +1,30 @@
+package shop.nandoShop.nandoshop_app.services.impl;
+
+import com.cloudinary.Cloudinary;
+import com.cloudinary.utils.ObjectUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import shop.nandoShop.nandoshop_app.dtos.AssetDTO;
+import shop.nandoShop.nandoshop_app.services.interfaces.AssetsService;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class CloudinaryAssetsServiceImpl implements AssetsService {
+
+    private final Cloudinary cloudinary;
+
+    public CloudinaryAssetsServiceImpl(Cloudinary cloudinary) {
+        this.cloudinary = cloudinary;
+    }
+
+    @Override
+    public AssetDTO uploadFile(MultipartFile file) throws IOException {
+        Map<String, Object> options = new HashMap<>();
+        return new AssetDTO(cloudinary.uploader().upload(file.getBytes(), options)
+        );
+    }
+}

--- a/src/main/java/shop/nandoShop/nandoshop_app/services/impl/ProductServiceImpl.java
+++ b/src/main/java/shop/nandoShop/nandoshop_app/services/impl/ProductServiceImpl.java
@@ -7,7 +7,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
+import shop.nandoShop.nandoshop_app.dtos.AssetDTO;
 import shop.nandoShop.nandoshop_app.dtos.ProductResponseDTO;
 import shop.nandoShop.nandoshop_app.dtos.requests.ProductRequest;
 import shop.nandoShop.nandoshop_app.dtos.requests.UpdateStockRequest;
@@ -19,6 +21,7 @@ import shop.nandoShop.nandoshop_app.exceptions.NotFoundException;
 import shop.nandoShop.nandoshop_app.repositories.CategoryRepository;
 import shop.nandoShop.nandoshop_app.repositories.ProductRepository;
 import shop.nandoShop.nandoshop_app.repositories.UserRepository;
+import shop.nandoShop.nandoshop_app.services.interfaces.AssetsService;
 import shop.nandoShop.nandoshop_app.services.interfaces.ProductService;
 import shop.nandoShop.nandoshop_app.utils.AuthUtil;
 
@@ -39,12 +42,17 @@ public class ProductServiceImpl implements ProductService {
     @Autowired
     UserServiceImpl userService;
 
+    @Autowired
+    AssetsService assetsService;
+
     @Override
     public Product create(ProductRequest productRequest) {
         try {
             User user = userService.getCurrentUser();
 
             Category category = categoryRepository.getById(productRequest.getCategoryId());
+
+            AssetDTO imageUrl = assetsService.uploadFile(productRequest.getImage());
 
             Product product = new Product();
             product.setCategory(category);
@@ -53,7 +61,7 @@ public class ProductServiceImpl implements ProductService {
             product.setDescription(productRequest.getDescription());
             product.setPrice(productRequest.getPrice());
             product.setStock(productRequest.getStock());
-
+            product.setImageUrl(imageUrl.url());
             productRepository.save(product);
             return product;
         }
@@ -72,6 +80,7 @@ public class ProductServiceImpl implements ProductService {
                         product.getId(),
                         product.getCategory().getName(),
                         product.getName(),
+                        product.getImageUrl(),
                         product.getDescription(),
                         product.getPrice(),
                         product.getStock(),

--- a/src/main/java/shop/nandoShop/nandoshop_app/services/interfaces/AssetsService.java
+++ b/src/main/java/shop/nandoShop/nandoshop_app/services/interfaces/AssetsService.java
@@ -1,0 +1,10 @@
+package shop.nandoShop.nandoshop_app.services.interfaces;
+
+import org.springframework.web.multipart.MultipartFile;
+import shop.nandoShop.nandoshop_app.dtos.AssetDTO;
+
+import java.io.IOException;
+
+public interface AssetsService {
+    AssetDTO uploadFile(MultipartFile file) throws IOException;
+}

--- a/src/main/java/shop/nandoShop/nandoshop_app/services/interfaces/ProductService.java
+++ b/src/main/java/shop/nandoShop/nandoshop_app/services/interfaces/ProductService.java
@@ -1,5 +1,6 @@
 package shop.nandoShop.nandoshop_app.services.interfaces;
 
+import org.springframework.web.multipart.MultipartFile;
 import shop.nandoShop.nandoshop_app.dtos.ProductResponseDTO;
 import shop.nandoShop.nandoshop_app.dtos.requests.ProductRequest;
 import shop.nandoShop.nandoshop_app.dtos.requests.UpdateStockRequest;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,5 @@ allowed.origins=http://localhost:3000,https://test.nandoshop.shop
 
 # Credenciales google
 google.client.id=${GOOGLE_CLIENT_ID}
+# Cloudinary
+cloudinary.url=${CLOUDINARY_URL}


### PR DESCRIPTION
This pull request introduces Cloudinary integration to handle image uploads for products in the NandoShop application. It includes changes to add Cloudinary dependencies, configure Cloudinary, update the product creation flow to support image uploads, and modify the data model to store image URLs. Below are the most important changes grouped by theme:

### Cloudinary Integration:
* Added Cloudinary dependencies (`cloudinary-http5` and `cloudinary-taglib`) to the `pom.xml` file.
* Created `CloudinaryConfig` to configure Cloudinary using a URL from application properties.
* Added the `cloudinary.url` property to `application.properties` for configuration.

### Product Image Upload:
* Updated `ProductRequest` to include a `MultipartFile` field for image uploads.
* Modified `ProductController` to accept `multipart/form-data` for product creation and map the response to `ProductResponseDTO`.
* Updated `ProductServiceImpl` to use `AssetsService` for uploading images to Cloudinary and storing the image URL in the database. [[1]](diffhunk://#diff-5e916712fa40c45194e56a3b338590a212b0ef44f05892c9b287efc661c86abcR45-R64) [[2]](diffhunk://#diff-5e916712fa40c45194e56a3b338590a212b0ef44f05892c9b287efc661c86abcR83)

### Data Model Updates:
* Added an `imageUrl` field to the `Product` entity to store the URL of the uploaded image.
* Updated `ProductResponseDTO` to include an `image` field for the image URL.

### Supporting Classes:
* Created `AssetDTO` to encapsulate Cloudinary asset details like URL and public ID.
* Added `ProductMapper` to map `Product` entities to `ProductResponseDTO`.
* Implemented `CloudinaryAssetsServiceImpl` to handle file uploads to Cloudinary.
* Introduced `AssetsService` interface for asset management.