### PR TITLE
feat(webhook-mercadopago): agregue controlador para recibir los webhooks

### DIFF
--- a/src/main/java/shop/nandoShop/nandoshop_app/config/SecurityConfig.java
+++ b/src/main/java/shop/nandoShop/nandoshop_app/config/SecurityConfig.java
@@ -41,7 +41,7 @@ public class SecurityConfig {
                                 "/v1/products/random/8",
                                 "/v1/payments/create",
                                 "/v1/product/**",
-                                "/v1/webhook/mp"
+                                "/v1/webhook/mercadopago"
                         ).permitAll()
                         .requestMatchers(HttpMethod.GET, "/v1/my_products").hasAuthority("SELLER")
                         .requestMatchers(HttpMethod.POST, "/v1/product").hasAnyAuthority("SELLER")

--- a/src/main/java/shop/nandoShop/nandoshop_app/controllers/v1/WebhookController.java
+++ b/src/main/java/shop/nandoShop/nandoshop_app/controllers/v1/WebhookController.java
@@ -1,0 +1,46 @@
+package shop.nandoShop.nandoshop_app.controllers.v1;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StreamUtils;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import shop.nandoShop.nandoshop_app.services.interfaces.WebhookService;
+
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Validated
+@RestController
+@RequestMapping("/v1/webhook")
+@RequiredArgsConstructor
+public class WebhookController {
+
+    private final WebhookService webhookService;
+
+    @PostMapping("/{platform}")
+    public ResponseEntity<Void> receiveWebhook(
+            @PathVariable String platform,
+            HttpServletRequest request
+    ) {
+        try {
+            String body = StreamUtils.copyToString(request.getInputStream(), StandardCharsets.UTF_8);
+
+            log.info("[WEBHOOK] Plataforma: {}, Payload recibido: {}", platform, body);
+
+            webhookService.processWebhook(platform, body);
+
+            return ResponseEntity.ok().build(); // Devolvemos rápido para que no reintente la pasarela
+
+        } catch (Exception e) {
+            log.error("Error al procesar webhook para plataforma: {}", platform, e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+}

--- a/src/main/java/shop/nandoShop/nandoshop_app/services/impl/WebhookServiceImpl.java
+++ b/src/main/java/shop/nandoShop/nandoshop_app/services/impl/WebhookServiceImpl.java
@@ -1,0 +1,32 @@
+package shop.nandoShop.nandoshop_app.services.impl;
+
+import org.springframework.stereotype.Service;
+import shop.nandoShop.nandoshop_app.services.interfaces.WebhookService;
+import shop.nandoShop.nandoshop_app.strategies.interfaces.WebhookStrategy;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class WebhookServiceImpl implements WebhookService {
+
+    private final Map<String, WebhookStrategy> strategies;
+
+    public WebhookServiceImpl(List<WebhookStrategy> strategyList) {
+        this.strategies = new HashMap<>();
+        for (WebhookStrategy strategy : strategyList) {
+            String name = strategy.getClass().getAnnotation(Service.class).value(); // usa el nombre del @Service("x")
+            this.strategies.put(name.toLowerCase(), strategy);
+        }
+    }
+
+    public void processWebhook(String platform, String payload) {
+        WebhookStrategy strategy = strategies.get(platform.toLowerCase());
+        if (strategy == null) {
+            throw new IllegalArgumentException("No existe estrategia para la plataforma: " + platform);
+        }
+        strategy.handle(payload);
+    }
+
+}

--- a/src/main/java/shop/nandoShop/nandoshop_app/services/interfaces/WebhookService.java
+++ b/src/main/java/shop/nandoShop/nandoshop_app/services/interfaces/WebhookService.java
@@ -1,0 +1,7 @@
+package shop.nandoShop.nandoshop_app.services.interfaces;
+
+import java.util.List;
+
+public interface WebhookService {
+    public void processWebhook(String platform, String payload);
+}

--- a/src/main/java/shop/nandoShop/nandoshop_app/strategies/interfaces/WebhookStrategy.java
+++ b/src/main/java/shop/nandoShop/nandoshop_app/strategies/interfaces/WebhookStrategy.java
@@ -1,0 +1,5 @@
+package shop.nandoShop.nandoshop_app.strategies.interfaces;
+
+public interface WebhookStrategy {
+    void handle(String payload);
+}

--- a/src/main/java/shop/nandoShop/nandoshop_app/strategies/mercadopago/MercadoPagoWebhookStrategy.java
+++ b/src/main/java/shop/nandoShop/nandoshop_app/strategies/mercadopago/MercadoPagoWebhookStrategy.java
@@ -1,0 +1,13 @@
+package shop.nandoShop.nandoshop_app.strategies.mercadopago;
+
+import org.springframework.stereotype.Service;
+import shop.nandoShop.nandoshop_app.strategies.interfaces.WebhookStrategy;
+
+@Service("mercadopago")
+public class MercadoPagoWebhookStrategy implements WebhookStrategy {
+    @Override
+    public void handle(String payload) {
+        // Aquí parseas el JSON y haces el trabajo real
+        System.out.println("Procesando MercadoPago: " + payload);
+    }
+}


### PR DESCRIPTION
This pull request introduces a new, extensible webhook handling system using the strategy pattern. It adds a generic `WebhookController` that routes incoming webhook requests to platform-specific strategies via a new `WebhookService`. The initial implementation supports MercadoPago webhooks and updates the security configuration to reflect the new endpoint.

**Webhook infrastructure and extensibility:**

* Added a generic `WebhookController` (`WebhookController.java`) that receives webhooks at `/v1/webhook/{platform}` and delegates processing to a service, logging payloads and handling errors gracefully.
* Introduced a `WebhookService` interface and its implementation (`WebhookServiceImpl.java`) that dispatches webhook payloads to the appropriate `WebhookStrategy` based on the platform path variable. [[1]](diffhunk://#diff-26f39337834d74bf315fbc7364de675b2bb92e1ec7abfed38bc14a2db3dc549cR1-R7) [[2]](diffhunk://#diff-ae73fac21b4b7fcb3397658ba0def63b80e885e99d4a501ef929c12a891b5955R1-R32)
* Defined a `WebhookStrategy` interface for platform-specific webhook handling logic.
* Implemented the `MercadoPagoWebhookStrategy` as the first supported platform, using the strategy pattern for easy extensibility.

**Security configuration:**

* Updated the security configuration to permit requests to the new `/v1/webhook/mercadopago` endpoint (renaming from `/v1/webhook/mp`).